### PR TITLE
Add section link to section title

### DIFF
--- a/lib/schema_doctor/exporter.rb
+++ b/lib/schema_doctor/exporter.rb
@@ -23,6 +23,7 @@ module SchemaDoctor
           :toclevels: 1
           :toc-title: Table of Contents
           :linkattrs:
+          :sectlinks:
 
         TEXT
 

--- a/lib/schema_doctor/exporter.rb
+++ b/lib/schema_doctor/exporter.rb
@@ -24,6 +24,7 @@ module SchemaDoctor
           :toc-title: Table of Contents
           :linkattrs:
           :sectlinks:
+          :sectanchors:
 
         TEXT
 


### PR DESCRIPTION
Add `:sectlinks:` to asciidoc configuration.

When a user clicks on section-title, the user can get a URL of the section.

<img width="1044" alt="スクリーンショット 2024-08-04 17 07 30" src="https://github.com/user-attachments/assets/b9053594-fdce-4c3c-9712-3f99f0c2de6a">
