### PR TITLE
Fix `Psych::DisallowedClass` Exception

### DIFF
--- a/lib/schema_doctor.rb
+++ b/lib/schema_doctor.rb
@@ -4,6 +4,7 @@ require_relative "schema_doctor/version"
 require_relative "schema_doctor/schema_file"
 require_relative "schema_doctor/analyzer"
 require_relative "schema_doctor/exporter"
+require_relative "schema_doctor/utils"
 require_relative "schema_doctor/railtie"
 
 module SchemaDoctor

--- a/lib/schema_doctor/analyzer.rb
+++ b/lib/schema_doctor/analyzer.rb
@@ -103,7 +103,7 @@ module SchemaDoctor
             name: association.name,
             class_name: association.class_name,
             foreign_key: association.foreign_key,
-            options: association.options,
+            options: Utils.sefety_dump_hash(association.options),
             polymorphic: association.polymorphic?
           }
         when /\Ahas/
@@ -111,7 +111,7 @@ module SchemaDoctor
             macro: association.macro.to_s,
             name: association.name,
             class_name: association.class_name,
-            options: association.options
+            options: Utils.sefety_dump_hash(association.options)
           }
         else
           puts "Unknown association type: #{association.macro}: :#{association.name}"

--- a/lib/schema_doctor/utils.rb
+++ b/lib/schema_doctor/utils.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SchemaDoctor
+  class Utils
+    class << self
+      def sefety_dump_hash(obj)
+        case obj
+        when Hash
+          obj.transform_values { |v| sefety_dump_hash(v) }
+        when Array
+          obj.map { |v| sefety_dump_hash(v) }
+        when TrueClass, FalseClass, NilClass, Integer, Float, String
+          obj
+        else
+          obj.to_s
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Problem
  - Call YAML::Load and occurs `Psych::DisallowedClass` if `Model.options` values contain Class object.

```
$ rails schema:export
== Loading model specifications...
bin/rails aborted!
Psych::DisallowedClass: Tried to load unspecified class: Tag (Psych::DisallowedClass)

Tasks: TOP => schema:export
(See full trace by running task with --trace)
```