### PR TITLE
Change the yml's key from symbol to string.

### DIFF
--- a/lib/schema_doctor.rb
+++ b/lib/schema_doctor.rb
@@ -5,7 +5,7 @@ require_relative "schema_doctor/schema_file"
 require_relative "schema_doctor/analyzer"
 require_relative "schema_doctor/exporter"
 require_relative "schema_doctor/utils"
-require_relative "schema_doctor/railtie"
+require_relative "schema_doctor/railtie" if defined?(Rails::Railtie)
 
 module SchemaDoctor
   class Error < StandardError; end

--- a/lib/schema_doctor/analyzer.rb
+++ b/lib/schema_doctor/analyzer.rb
@@ -25,7 +25,7 @@ module SchemaDoctor
         next if model.table_name.blank?
 
         puts "Processing #{model.name}..."
-        schema[model.name] =
+        schema[model.name.to_sym] =
           {
             name: model.name,
             table_name: model.table_name,
@@ -61,7 +61,7 @@ module SchemaDoctor
 
     def columns(model, columns = {})
       model.columns.each do |column|
-        columns[column.name] =
+        columns[column.name.to_sym] =
           {
             name: column.name,
             type: column.type,
@@ -80,7 +80,7 @@ module SchemaDoctor
 
     def indexes(model)
       connection.indexes(model.table_name).each_with_object({}) do |index, hash|
-        hash[index.name] = {
+        hash[index.name.to_sym] = {
           name: index.name,
           columns: index.columns,
           unique: index.unique,
@@ -98,7 +98,7 @@ module SchemaDoctor
       model.reflect_on_all_associations.each do |association|
         case association.macro.to_s
         when /\Abelongs_to/
-          result[:belongs][association.name] = {
+          result[:belongs][association.name.to_sym] = {
             macro: association.macro.to_s,
             name: association.name,
             class_name: association.class_name,
@@ -107,7 +107,7 @@ module SchemaDoctor
             polymorphic: association.polymorphic?
           }
         when /\Ahas/
-          result[:has][association.name] = {
+          result[:has][association.name.to_sym] = {
             macro: association.macro.to_s,
             name: association.name,
             class_name: association.class_name,

--- a/lib/schema_doctor/schema_file.rb
+++ b/lib/schema_doctor/schema_file.rb
@@ -9,14 +9,14 @@ module SchemaDoctor
 
       # Load schema specification files and merge them into a single hash
       Dir.glob("#{schema_dir}/*").inject({}) do |hash, file|
-        hash.merge(YAML.load_file(file))
+        hash.merge(YAML.load_file(file, symbolize_names: true))
       end
     end
 
     def dump(specs)
       # Output specification files for each model
       FileUtils.mkdir_p(schema_dir)
-      specs.each do |name, spec|
+      Utils.deep_stringify(specs).each do |name, spec|
         File.open("#{schema_dir}/#{name}.yml", "w") do |f|
           YAML.dump({name => spec}, f)
         end

--- a/lib/schema_doctor/utils.rb
+++ b/lib/schema_doctor/utils.rb
@@ -15,6 +15,17 @@ module SchemaDoctor
           obj.to_s
         end
       end
+
+      def deep_stringify(obj)
+        case obj
+        when Hash
+          obj.transform_keys(&:to_s).transform_values { |v| deep_stringify(v) }
+        when Array
+          obj.map { |v| deep_stringify(v) }
+        else
+          obj
+        end
+      end
     end
   end
 end

--- a/spec/schema_doctor_spec.rb
+++ b/spec/schema_doctor_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe SchemaDoctor do
   it "has a version number" do
     expect(SchemaDoctor::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
- Improve readability generated .yml files.


Before:
```yml
---
Account:
  :name: Account
  :table_name: accounts
  :table_comment:
  :extra_comment:
  :columns:
    id:
      :name: id
      :type: :integer
      :sql_type: bigint
      :default:
      :null: false
      :limit: 8
      :precision:
      :scale:
      :column_comment:
      :extra_comment:
```

After:
```yml
---
Account:
  name: Account
  table_name: accounts
  table_comment:
  extra_comment:
  columns:
    id:
      name: id
      type: :integer
      sql_type: bigint
      default:
      'null': false
      limit: 8
      precision:
      scale:
      column_comment:
      extra_comment:
```